### PR TITLE
Ensure that functions.php is loaded when saving admin options.

### DIFF
--- a/includes/admin.php
+++ b/includes/admin.php
@@ -20,5 +20,6 @@ foreach ( array( 'options-writing.php', 'post.php', 'post-new.php' ) as $p ) {
 
 // Save routine for "Settings > Writing" page.
 add_action( 'load-options.php', function() {
+	require_once __DIR__ . '/functions.php';
 	require __DIR__ . '/admin-save-options.php';
 } );


### PR DESCRIPTION
Otherwise `cac_cc_validate_license()` is not available.

See https://redmine.gc.cuny.edu/issues/11803.